### PR TITLE
allow illuminate/queue to be 5.6.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "require": {
     "php": ">=7.0",
-    "illuminate/queue": "5.5.*",
+    "illuminate/queue": "5.5.* || 5.6.*",
     "microsoft/azure-storage-queue": "~1.0.0"
   },
   "require-dev": {


### PR DESCRIPTION
allow illuminate/queue to be 5.6.*

* https://raw.githubusercontent.com/illuminate/queue/v5.6.39/Queue.php
* https://raw.githubusercontent.com/illuminate/queue/v5.5.40/Queue.php

Comparing the diff manually,
it contains only diff of `protected $encrypter` which not being referenced inside

Assume safe to update