### PR TITLE
Enable laravel up to 5.8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
   ],
   "require": {
     "php": ">=7.0",
-    "illuminate/queue": "~5.5",
+    "illuminate/queue": ">=5.7.7 || < 6.0",
     "microsoft/azure-storage-queue": "~1.0.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~6.0 || ~7.0",
-    "orchestra/testbench": "~3.5",
+    "orchestra/testbench": "~3.7",
     "mockery/mockery": "~1.0@dev",
     "satooshi/php-coveralls": "~1.0.1"
   },

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
   ],
   "require": {
     "php": ">=7.0",
-    "illuminate/queue": "5.5.* || 5.6.*",
+    "illuminate/queue": "~5.5",
     "microsoft/azure-storage-queue": "~1.0.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~6.0",
-    "orchestra/testbench": "3.5.*",
+    "phpunit/phpunit": "~6.0 || ~7.0",
+    "orchestra/testbench": "~3.5",
     "mockery/mockery": "~1.0@dev",
     "satooshi/php-coveralls": "~1.0.1"
   },

--- a/src/AzureQueue.php
+++ b/src/AzureQueue.php
@@ -59,7 +59,7 @@ class AzureQueue extends Queue implements QueueInterface
      */
     public function push($job, $data = '', $queue = null)
     {
-        $this->pushRaw($this->createPayload($job, $data), $queue);
+        $this->pushRaw($this->createPayload($job, $this->getQueue($queue), $data), $queue);
     }
 
     /**
@@ -88,7 +88,7 @@ class AzureQueue extends Queue implements QueueInterface
      */
     public function later($delay, $job, $data = '', $queue = null)
     {
-        $payload = $this->createPayload($job, $data);
+        $payload = $this->createPayload($job, $this->getQueue($queue), $data);
 
         $options = new CreateMessageOptions();
         $options->setVisibilityTimeoutInSeconds($this->secondsUntil($delay));

--- a/tests/AzureConnectorTest.php
+++ b/tests/AzureConnectorTest.php
@@ -18,7 +18,7 @@ class AzureConnectorTest extends TestCase
      */
     protected $queueRestProxy;
 
-    public function setUp()
+    protected function setUp():void
     {
         parent::setUp();
 

--- a/tests/AzureJobTest.php
+++ b/tests/AzureJobTest.php
@@ -28,7 +28,7 @@ class AzureJobTest extends TestCase
      */
     protected $job;
 
-    public function setUp()
+    protected function setUp():void
     {
         parent::setUp();
 

--- a/tests/AzureQueueTest.php
+++ b/tests/AzureQueueTest.php
@@ -18,7 +18,7 @@ class AzureQueueTest extends TestCase
      */
     protected $queue;
 
-    public function setUp()
+    public function setUp():void
     {
         parent::setUp();
         $this->azure = Mockery::mock(\MicrosoftAzure\Storage\Queue\Internal\IQueue::class);
@@ -41,7 +41,7 @@ class AzureQueueTest extends TestCase
     {
         $this->azure->shouldReceive('createMessage')->once()->withArgs([
             "myqueue",
-            '{"displayName":"job","job":"job","maxTries":null,"timeout":null,"data":"data"}'
+            '{"displayName":"job","job":"job","maxTries":null,"delay":null,"timeout":null,"data":"data"}'
         ]);
         $this->queue->push('job', 'data');
     }
@@ -113,7 +113,7 @@ class AzureQueueTest extends TestCase
     {
         $this->azure->shouldReceive('createMessage')->once()->withArgs(
             function ($queue, $payload, CreateMessageOptions $options) {
-                return $queue == 'myqueue' && $payload == '{"displayName":"job","job":"job","maxTries":null,"timeout":null,"data":"data"}' && $options->getVisibilityTimeoutInSeconds() == 10;
+                return $queue == 'myqueue' && $payload == '{"displayName":"job","job":"job","maxTries":null,"delay":null,"timeout":null,"data":"data"}' && $options->getVisibilityTimeoutInSeconds() == 10;
             }
         );
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,10 +15,10 @@ abstract class TestCase extends Orchestra\Testbench\TestCase
         return [];
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         $this->addToAssertionCount(Mockery::getContainer()->mockery_getExpectationCount());
         Mockery::close();
     }
-
+    
 }


### PR DESCRIPTION
This change will allow laravel update until version 5.8.x

Minimum is set to be 5.7.7 since there is a change on message payload creation at that version.

- It now requires 3 parameters to be sent
- payload now includes delay in json (need to test if any error would be generated)
https://github.com/illuminate/queue/blob/8191d42edc4c4fdf95d6c945535b1800c59c88ab/Queue.php#L86-L97

git blame:
https://github.com/illuminate/queue/commit/8191d42edc4c4fdf95d6c945535b1800c59c88ab

Test was run....

## Suggestion
- Change the minor version instead of patch version
- Consider to merge with squigg repo for more updates